### PR TITLE
Stop forking so Upstart can track status of consul

### DIFF
--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -20,7 +20,7 @@ script
 
   # Set GOMAXPROCS to use all our CPUs, because Consul can block a scheduler thread
   # Use su to become consul user non-interactively on old Upstart versions (see http://superuser.com/a/234541/76168)
-  exec su -s /bin/sh -c 'GOMAXPROCS=`nproc` exec "$0" "$@" &>>{{ consul_log_file }}' consul -- /opt/consul/bin/consul agent \
+  exec su -s /bin/sh -c 'GOMAXPROCS=`nproc` exec "$0" "$@"' consul -- /opt/consul/bin/consul agent \
 {% if consul_dynamic_bind %}
     -bind=$BIND \
 {% endif %}


### PR DESCRIPTION
Backgrounding the process makes Upstart sad.

Additionally, we just log to /var/log/upstart/consul.